### PR TITLE
CreditCard One-Click Checkout Issues

### DIFF
--- a/Components/Payments/CreditCardPayment.php
+++ b/Components/Payments/CreditCardPayment.php
@@ -398,20 +398,21 @@ class CreditCardPayment extends Payment implements
             return;
         }
 
-        $tokenId             = $params['token_id'];
+        $token               = $params['token_id'];
         $userId              = $sessionManager->getUserId();
         $billingAddress      = $sessionManager->getOrderBilldingAddress();
         $shippingAddress     = $sessionManager->getOrderShippingAddress();
         $billingAddressHash  = $this->createAddressHash($billingAddress);
         $shippingAddressHash = $this->createAddressHash($shippingAddress);
 
-        $transactionDetails = $transactionService->getTransactionByTransactionId(
+        $transaction = $transactionService->getTransactionByTransactionId(
             $params['transaction_id'],
             CreditCardTransaction::NAME
         );
+        $cardInfo    = isset($transaction['payment']['card']) ? $transaction['payment']['card'] : [];
 
         $creditCardVault = $this->em->getRepository(CreditCardVault::class)->findOneBy([
-            'id'                      => $tokenId,
+            'token'                   => $token,
             'userId'                  => $userId,
             'bindBillingAddressHash'  => $billingAddressHash,
             'bindShippingAddressHash' => $shippingAddressHash,
@@ -419,7 +420,7 @@ class CreditCardPayment extends Payment implements
 
         if (! $creditCardVault) {
             $creditCardVault = new CreditCardVault();
-            $creditCardVault->setToken($tokenId);
+            $creditCardVault->setToken($token);
             $creditCardVault->setMaskedAccountNumber($params['masked_account_number']);
             $creditCardVault->setUserId($userId);
             $creditCardVault->setBindBillingAddress($billingAddress);
@@ -428,14 +429,13 @@ class CreditCardPayment extends Payment implements
             $creditCardVault->setBindShippingAddressHash($shippingAddressHash);
             $this->em->persist($creditCardVault);
         }
-
         $creditCardVault->setLastUsed(new \DateTime());
         $creditCardVault->setAdditionalData([
             'firstName'       => isset($params['first_name']) ? $params['first_name'] : '',
             'lastName'        => isset($params['last_name']) ? $params['last_name'] : '',
-            'expirationMonth' => $transactionDetails['payment']['card']['expiration-month'],
-            'expirationYear'  => $transactionDetails['payment']['card']['expiration-year'],
-            'cardType'        => $transactionDetails['payment']['card']['card-type'],
+            'expirationMonth' => isset($cardInfo['expiration-month']) ? $cardInfo['expiration-month'] : '',
+            'expirationYear'  => isset($cardInfo['expiration-year']) ? $cardInfo['expiration-year'] : '',
+            'cardType'        => isset($cardInfo['card-type']) ? $cardInfo['card-type'] : '',
         ]);
         $this->em->flush();
     }

--- a/Components/Services/NotificationHandler.php
+++ b/Components/Services/NotificationHandler.php
@@ -68,7 +68,6 @@ class NotificationHandler extends Handler
      * @param BackendService  $backendService
      *
      * @return Transaction
-     * @throws \WirecardElasticEngine\Exception\InitialTransactionNotFoundException
      * @since 1.0.0
      */
     protected function handleSuccess(
@@ -88,10 +87,11 @@ class NotificationHandler extends Handler
                     "No matching transaction for " . PoiPiaTransaction::NAME
                     . " payment with PTRID '{$response->getProviderTransactionReference()}' found"
                 );
-                $initialTransaction = new Transaction(Transaction::TYPE_INITIAL_RESPONSE);
-                return $initialTransaction;
             }
-            throw $exception;
+            $initialTransaction = new Transaction(Transaction::TYPE_INITIAL_RESPONSE);
+            $initialTransaction->setPaymentStatus($paymentStatusId);
+            $this->logger->info("Notification arrived before initial transaction");
+            return $initialTransaction;
         }
 
         // POI/PIA: Set payment status "review necessary", if PTRID of initial transaction and notification do not match

--- a/Components/Services/TransactionManager.php
+++ b/Components/Services/TransactionManager.php
@@ -104,7 +104,7 @@ class TransactionManager
         $transactions = $this->em->getRepository(Transaction::class)
                                  ->findBy(['paymentUniqueId' => $initialTransaction->getPaymentUniqueId()]);
         foreach ($transactions as $transaction) {
-            if ($transaction->getId() !== $initialTransaction->getId() && $initialTransaction->isInitial()) {
+            if ($transaction->getId() !== $initialTransaction->getId()) {
                 $transaction->setOrderNumber($initialTransaction->getOrderNumber());
             }
         }

--- a/Components/Services/TransactionManager.php
+++ b/Components/Services/TransactionManager.php
@@ -201,6 +201,28 @@ class TransactionManager
     }
 
     /**
+     * Calculate remaining amount for backend operations
+     *
+     * @param Transaction $transaction
+     *
+     * @return float
+     *
+     * @since 1.1.0
+     */
+    public function getRemainingAmount(Transaction $transaction)
+    {
+        $totalAmount       = (float)$transaction->getAmount();
+        $childTransactions = $this->em->getRepository(Transaction::class)->findBy([
+            'parentTransactionId' => $transaction->getTransactionId(),
+            'type'                => Transaction::TYPE_BACKEND,
+        ]);
+        foreach ($childTransactions as $childTransaction) {
+            $totalAmount -= (float)$childTransaction->getAmount();
+        }
+        return $totalAmount;
+    }
+
+    /**
      * @param Transaction $transaction
      *
      * @return Transaction

--- a/Components/Services/TransactionManager.php
+++ b/Components/Services/TransactionManager.php
@@ -185,6 +185,7 @@ class TransactionManager
         $childTransactions = $repo->findBy([
             'parentTransactionId' => $transaction->getParentTransactionId(),
             'transactionType'     => $transaction->getTransactionType(),
+            'type'                => Transaction::TYPE_BACKEND,
         ]);
         foreach ($parentTransactions as $parentTransaction) {
             $totalAmount = (float)$parentTransaction->getAmount();

--- a/Controllers/Backend/WirecardElasticEngineTransactions.php
+++ b/Controllers/Backend/WirecardElasticEngineTransactions.php
@@ -109,14 +109,15 @@ class Shopware_Controllers_Backend_WirecardElasticEngineTransactions extends Sho
             return $this->handleError('No transactions found');
         }
 
-        $shop           = $this->getModelManager()->getRepository(Shop::class)->getActiveDefault();
-        $config         = $payment->getTransactionConfig(
+        $transactionManager = $this->container->get('wirecard_elastic_engine.transaction_manager');
+        $shop               = $this->getModelManager()->getRepository(Shop::class)->getActiveDefault();
+        $config             = $payment->getTransactionConfig(
             $shop,
             $this->container->getParameterBag(),
             $shop->getCurrency()->getCurrency()
         );
-        $backendService = new BackendService($config, $this->getLogger());
-        $result         = [
+        $backendService     = new BackendService($config, $this->getLogger());
+        $result             = [
             'transactions' => [],
         ];
 
@@ -138,6 +139,7 @@ class Shopware_Controllers_Backend_WirecardElasticEngineTransactions extends Sho
 
             $result['transactions'][] = array_merge($transaction->toArray(), [
                 'backendOperations' => $backendOperations,
+                'remainingAmount'   => $transactionManager->getRemainingAmount($transaction),
                 'isFinal'           => $backendService->isFinal($transaction->getTransactionType()),
             ]);
         }

--- a/Controllers/Frontend/WirecardElasticEnginePayment.php
+++ b/Controllers/Frontend/WirecardElasticEnginePayment.php
@@ -434,13 +434,11 @@ class Shopware_Controllers_Frontend_WirecardElasticEnginePayment extends Shopwar
      */
     public function deleteCreditCardTokenAction()
     {
-        $em      = $this->container->get('models');
-        $userId  = $this->container->get('session')->offsetGet('sUserId');
-        $tokenId = $this->Request()->getParam('token');
+        $em = $this->getModelManager();
 
         $creditCardVault = $em->getRepository(CreditCardVault::class)->findOneBy([
-            'userId' => $userId,
-            'token'  => $tokenId,
+            'id'     => $this->Request()->getParam('token'),
+            'userId' => $this->getSessionManager()->getUserId(),
         ]);
         if ($creditCardVault) {
             $em->remove($creditCardVault);

--- a/Controllers/Frontend/WirecardElasticEnginePayment.php
+++ b/Controllers/Frontend/WirecardElasticEnginePayment.php
@@ -232,10 +232,15 @@ class Shopware_Controllers_Frontend_WirecardElasticEnginePayment extends Shopwar
             $orderStatus = Status::ORDER_STATE_CLARIFICATION_REQUIRED;
         }
 
-        // check if payment status has already been set by notification (see NotificationHandler)
+        // check if status has been set by notification via initial or notify transaction (see NotificationHandler)
         $paymentStatus = Status::PAYMENT_STATE_OPEN;
         if ($initialTransaction->getPaymentStatus()) {
             $paymentStatus = $initialTransaction->getPaymentStatus();
+        } else {
+            $notifyTransaction = $transactionManager->findNotificationTransaction($initialTransaction);
+            if ($notifyTransaction && $notifyTransaction->getPaymentStatus()) {
+                $paymentStatus = $notifyTransaction->getPaymentStatus();
+            }
         }
 
         $orderNumber = $this->saveOrder(
@@ -264,13 +269,20 @@ class Shopware_Controllers_Frontend_WirecardElasticEnginePayment extends Shopwar
         // check again if payment status has been set by notification and try to update payment status
         if (! $initialTransaction->getPaymentStatus()) {
             $this->getModelManager()->refresh($initialTransaction);
-            if ($initialTransaction->getPaymentStatus()) {
-                $this->getLogger()->debug('Payment status has changed to ' . $initialTransaction->getPaymentStatus());
+            $paymentStatus = $initialTransaction->getPaymentStatus();
+            if (! $paymentStatus) {
+                $notifyTransaction = $transactionManager->findNotificationTransaction($initialTransaction);
+                if ($notifyTransaction && $notifyTransaction->getPaymentStatus()) {
+                    $paymentStatus = $notifyTransaction->getPaymentStatus();
+                }
+            }
+            if ($paymentStatus) {
+                $this->getLogger()->debug('Payment status has changed to ' . $paymentStatus);
                 $this->savePaymentStatus(
                     $response->getTransactionId(),
                     $initialTransaction->getPaymentUniqueId(),
-                    $initialTransaction->getPaymentStatus(),
-                    NotificationHandler::shouldSendStatusMail($initialTransaction->getPaymentStatus())
+                    $paymentStatus,
+                    NotificationHandler::shouldSendStatusMail($paymentStatus)
                 );
             }
         }

--- a/Models/Transaction.php
+++ b/Models/Transaction.php
@@ -38,6 +38,7 @@ class Transaction extends ModelEntity
 {
     const TYPE_INITIAL_RESPONSE = 'initial-response';
     const TYPE_INITIAL_REQUEST = 'initial-request';
+    const TYPES_INITIAL = ['initial-response', 'initial-request'];
     const TYPE_BACKEND = 'backend';
     const TYPE_RETURN = 'return';
     const TYPE_INTERACTION = 'interaction';

--- a/Resources/views/backend/wirecard_elastic_engine_extend_order/view/detail/info_tab.js
+++ b/Resources/views/backend/wirecard_elastic_engine_extend_order/view/detail/info_tab.js
@@ -116,6 +116,7 @@ Ext.define('Shopware.apps.WirecardElasticEngineExtendOrder.view.detail.InfoTab',
                 'request',
                 'backendOperations',
                 'isFinal',
+                'remainingAmount',
                 'state',
                 'type',
                 'statusMessage'
@@ -260,7 +261,7 @@ Ext.define('Shopware.apps.WirecardElasticEngineExtendOrder.view.detail.InfoTab',
                 id: 'wirecardee-transaction-amount',
                 xtype: 'numberfield',
                 fieldLabel: me.snippets.amountDialog.fieldLabel,
-                value: transaction.amount
+                value: transaction.remainingAmount
             },
             buttons: [{
                 text: me.snippets.amountDialog.submit,

--- a/Resources/views/backend/wirecard_elastic_engine_extend_order/view/detail/info_tab.js
+++ b/Resources/views/backend/wirecard_elastic_engine_extend_order/view/detail/info_tab.js
@@ -442,17 +442,18 @@ Ext.define('Shopware.apps.WirecardElasticEngineExtendOrder.view.detail.InfoTab',
             },
             success: function (response) {
                 var data = Ext.decode(response.responseText);
-                var message = {
-                    title: me.snippets.operations.successTitle,
-                    text: me.snippets.operations.successMessage,
-                    width: 400
-                };
-
-                if (!data.success) {
-                    message.title = me.snippets.operations.errorTitle;
-                    message.text = data.message;
+                if (data.success) {
+                    Shopware.Notification.createGrowlMessage(
+                        me.snippets.operations.successTitle,
+                        me.snippets.operations.successMessage
+                    );
+                } else {
+                    Shopware.Notification.createStickyGrowlMessage({
+                        title: me.snippets.operations.errorTitle,
+                        text: data.message,
+                        width: 400
+                    });
                 }
-                Shopware.Notification.createStickyGrowlMessage(message);
                 me.loadStore();
                 if (Ext.getCmp('wirecardee-transaction-amount-window')) {
                     Ext.getCmp('wirecardee-transaction-amount-window').close();

--- a/Resources/views/backend/wirecard_elastic_engine_transactions/controller/main.js
+++ b/Resources/views/backend/wirecard_elastic_engine_transactions/controller/main.js
@@ -50,8 +50,7 @@ Ext.define('Shopware.apps.WirecardElasticEngineTransactions.controller.Main', {
         if (!form.isValid()) {
             Shopware.Notification.createGrowlMessage(
                 '{s name="Title" namespace="backend/wirecard_elastic_engine/support_mail"}{/s}',
-                '{s name="FormValidationError" namespace="backend/wirecard_elastic_engine/support_mail"}{/s}',
-                me.mainWindow.title
+                '{s name="FormValidationError" namespace="backend/wirecard_elastic_engine/support_mail"}{/s}'
             );
             me.mainWindow.setLoading(false);
             return;

--- a/Resources/views/backend/wirecard_elastic_engine_transactions/test_credentials.tpl
+++ b/Resources/views/backend/wirecard_elastic_engine_transactions/test_credentials.tpl
@@ -42,13 +42,14 @@
                         text += '<span style="color:green;font-weight:bold;">';
                         text += '{s name="TestCredentialsSuccessful" namespace="backend/wirecard_elastic_engine/common"}{/s}';
                         text += '</span>';
-                    } else {
-                        text += '<span style="color:red;font-weight:bold;">';
-                        text += '{s name="TestCredentialsFailed" namespace="backend/wirecard_elastic_engine/common"}{/s}';
-                        text += '</span>';
-                        if (data.msg) {
-                            text += '<br>' + data.msg;
-                        }
+                        Shopware.Notification.createGrowlMessage(title, text);
+                        return;
+                    }
+                    text += '<span style="color:red;font-weight:bold;">';
+                    text += '{s name="TestCredentialsFailed" namespace="backend/wirecard_elastic_engine/common"}{/s}';
+                    text += '</span>';
+                    if (data.msg) {
+                        text += '<br>' + data.msg;
                     }
                     Shopware.Notification.createStickyGrowlMessage({
                         title: title,

--- a/Resources/views/frontend/checkout/finish.tpl
+++ b/Resources/views/frontend/checkout/finish.tpl
@@ -26,7 +26,7 @@
     {$smarty.block.parent}
 {/block}
 
-{block name='frontend_checkout_finish_information_wrapper'}
+{block name='frontend_checkout_finish_teaser'}
     {if $wirecardElasticEngineBankData}
         <div class="panel has--border wirecardee--bankdata is--rounded finish--teaser">
             <div class="panel--title primary is--underline">

--- a/Tests/Selenium/Payments/CreditCardOneClickTest.js
+++ b/Tests/Selenium/Payments/CreditCardOneClickTest.js
@@ -1,0 +1,45 @@
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/shopware-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/shopware-ee/blob/master/LICENSE
+ */
+
+/* eslint-env mocha */
+
+const { By } = require('selenium-webdriver');
+const { config } = require('../config');
+const {
+    loginWithExampleAccount,
+    checkConfirmationPage,
+    addProductToCartAndGotoCheckout,
+    selectPaymentMethod,
+    getDriver
+} = require('../common');
+
+/**
+ * Credit Card One-click has to be enabled and a token must already exist (change config tokenId)
+ */
+describe('Credit Card One-Click Checkout test (NOTE: has requirements)', () => {
+    const driver = getDriver();
+
+    const paymentLabel = config.payments.creditCardOneClick.label;
+    const tokenId = config.payments.creditCardOneClick.tokenId;
+
+    it('should check the credit card one-click payment process', async () => {
+        await loginWithExampleAccount(driver);
+        await addProductToCartAndGotoCheckout(driver, '/genusswelten/tees-und-zubeh/tee-zubehoer/24/glas-teekaennchen');
+        await selectPaymentMethod(driver, paymentLabel);
+
+        await driver.findElement(By.id('wirecardee--token-' + tokenId)).click();
+
+        // Confirm order
+        console.log('click button confirm--form');
+        await driver.findElement(By.xpath('//button[@form="confirm--form"]')).click();
+
+        await checkConfirmationPage(driver, paymentLabel);
+    });
+
+    after(async () => driver.quit());
+});

--- a/Tests/Selenium/common.js
+++ b/Tests/Selenium/common.js
@@ -85,8 +85,8 @@ exports.selectPaymentMethod = async function (driver, paymentLabel) {
 exports.checkConfirmationPage = async function (driver, paymentLabel) {
     console.log('wait for .teaser--btn-print');
     await driver.wait(until.elementLocated(By.className('teaser--btn-print')), 30000);
-    console.log('expect content .panel--title');
-    const panelTitle = await driver.findElement(By.className('panel--title')).getText();
+    console.log('expect content h2.panel--title');
+    const panelTitle = await driver.findElement(By.css('h2.panel--title')).getText();
     expect(panelTitle).to.include('Vielen Dank');
     console.log('expect content .payment--content');
     const paymentContent = await driver.findElement(By.className('payment--content')).getText();

--- a/Tests/Selenium/config.js
+++ b/Tests/Selenium/config.js
@@ -30,6 +30,10 @@ exports.config = {
             },
             password: 'wirecard'
         },
+        creditCardOneClick: {
+            label: 'Wirecard Kreditkarte',
+            tokenId: '1'
+        },
         alipay: {
             label: 'Wirecard Alipay Cross-border',
             fields: {

--- a/Tests/Selenium/config.js
+++ b/Tests/Selenium/config.js
@@ -13,16 +13,6 @@ exports.config = {
         password: 'shopware'
     },
     payments: {
-        ratepay: {
-            label: 'Wirecard Kauf auf Rechnung mit Zahlungsgarantie'
-        },
-        paypal: {
-            label: 'Wirecard PayPal',
-            fields: {
-                email: 'paypal.shopware.buyer@wirecard.com',
-                password: 'Wirecardbuyer'
-            }
-        },
         creditCard: {
             label: 'Wirecard Kreditkarte',
             fields: {
@@ -48,12 +38,34 @@ exports.config = {
                 paymentPasswordDigit: '1'
             }
         },
+        ratepay: {
+            label: 'Wirecard Kauf auf Rechnung mit Zahlungsgarantie'
+        },
+        ideal: {
+            label: 'Wirecard iDEAL',
+            fields: {
+                bank: 'INGBNL2A'
+            }
+        },
         masterpass: {
             label: 'Wirecard Masterpass',
             fields: {
                 email: 'masterpass@mailadresse.net',
                 password: 'WirecardPass42'
             }
+        },
+        paypal: {
+            label: 'Wirecard PayPal',
+            fields: {
+                email: 'paypal.shopware.buyer@wirecard.com',
+                password: 'Wirecardbuyer'
+            }
+        },
+        pia: {
+            label: 'Wirecard Vorauskasse'
+        },
+        poi: {
+            label: 'Wirecard Kauf auf Rechnung'
         },
         sepa: {
             label: 'Wirecard SEPA-Lastschrift',
@@ -70,18 +82,6 @@ exports.config = {
                 userId: '1234',
                 password: 'passwd',
                 tan: '12345'
-            }
-        },
-        pia: {
-            label: 'Wirecard Vorauskasse'
-        },
-        poi: {
-            label: 'Wirecard Kauf auf Rechnung'
-        },
-        ideal: {
-            label: 'Wirecard iDEAL',
-            fields: {
-                bank: 'INGBNL2A'
             }
         },
         upi: {
@@ -301,10 +301,6 @@ exports.tests = [
         timeout: 120000
     },
     {
-        file: 'Payments/PaypalTest',
-        timeout: 180000
-    },
-    {
         file: 'Payments/CreditCardTest',
         timeout: 120000
     },
@@ -313,11 +309,43 @@ exports.tests = [
         timeout: 120000
     },
     {
-        file: 'Payments/SepaTest',
+        file: 'Payments/AlipayTest',
         timeout: 120000
     },
     {
+        file: 'Payments/RatepayTest',
+        timeout: 120000
+    },
+    {
+        file: 'Payments/IdealTest',
+        timeout: 120000
+    },
+    {
+        file: 'Payments/MasterpassTest',
+        timeout: 120000
+    },
+    {
+        file: 'Payments/PaypalTest',
+        timeout: 180000
+    },
+    {
+        file: 'Payments/PiaTest',
+        timeout: 90000
+    },
+    {
+        file: 'Payments/PoiTest',
+        timeout: 90000
+    },
+    {
+        file: 'Payments/SepaTest',
+        timeout: 90000
+    },
+    {
         file: 'Payments/SofortTest',
+        timeout: 120000
+    },
+    {
+        file: 'Payments/UpiTest',
         timeout: 120000
     }
 ];

--- a/Tests/Unit/Components/Payments/CreditCardPaymentTest.php
+++ b/Tests/Unit/Components/Payments/CreditCardPaymentTest.php
@@ -19,6 +19,7 @@ use Wirecard\PaymentSdk\Config\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\CreditCardTransaction;
+use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\TransactionService;
 use WirecardElasticEngine\Components\Actions\ErrorAction;
 use WirecardElasticEngine\Components\Actions\ViewAction;
@@ -195,7 +196,7 @@ class CreditCardPaymentTest extends PaymentTestCase
     public function testProcessPaymentWithVaultEnabled()
     {
         $orderSummary = $this->createMock(OrderSummary::class);
-        $orderSummary->method('getAdditionalPaymentData')->willReturn(['token' => 'FOOTOKEN123']);
+        $orderSummary->method('getAdditionalPaymentData')->willReturn(['token' => '2']);
         $userMapper = $this->createMock(UserMapper::class);
         $userMapper->expects($this->atLeastOnce())->method('getUserId')->willReturn(1);
         $userMapper->expects($this->atLeastOnce())->method('getBillingAddress')->willReturn([
@@ -212,10 +213,11 @@ class CreditCardPaymentTest extends PaymentTestCase
 
         $repo            = $this->createMock(EntityRepository::class);
         $creditCardVault = new CreditCardVault();
-        $lastUsed        = $creditCardVault->getLastUsed();
+        $creditCardVault->setToken('FOOTOKEN321');
+        $lastUsed = $creditCardVault->getLastUsed();
         $repo->expects($this->once())->method('findOneBy')->with([
             'userId'                  => 1,
-            'token'                   => 'FOOTOKEN123',
+            'id'                      => '2',
             'bindBillingAddressHash'  => '5958eb93c0b510df3961d03ff1bf3975',
             'bindShippingAddressHash' => 'e8269246ec003988d43a212a960f0518',
         ])->willReturn($creditCardVault);
@@ -319,6 +321,7 @@ class CreditCardPaymentTest extends PaymentTestCase
         $this->assertEquals([
             'method'       => CreditCardPayment::PAYMETHOD_IDENTIFIER,
             'vaultEnabled' => true,
+            'savedCards'   => [],
         ], $this->payment->getAdditionalViewAssignments($sessionManager));
 
         $creditCardVault = new CreditCardVault();
@@ -332,7 +335,7 @@ class CreditCardPaymentTest extends PaymentTestCase
             'vaultEnabled' => true,
             'savedCards'   => [
                 [
-                    'token'               => 'FOOTOKER321',
+                    'token'               => null,
                     'maskedAccountNumber' => '4444****8888',
                     'additionalData'      => ['add'],
                     'acceptedCriteria'    => false,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test:default": "node_modules/.bin/mocha Tests/Selenium/Payments/DefaultTest.js --timeout 120000",
     "test:creditcard": "node_modules/.bin/mocha Tests/Selenium/Payments/CreditCardTest.js --timeout 60000",
     "test:creditcard3ds": "node_modules/.bin/mocha Tests/Selenium/Payments/CreditCardThreeDTest.js --timeout 60000",
+    "test:creditcard1click": "node_modules/.bin/mocha Tests/Selenium/Payments/CreditCardOneClickTest.js --timeout 60000",
     "test:alipay": "node_modules/.bin/mocha Tests/Selenium/Payments/AlipayTest.js --timeout 120000",
     "test:ratepay": "node_modules/.bin/mocha Tests/Selenium/Payments/RatepayTest.js --timeout 60000",
     "test:ideal": "node_modules/.bin/mocha Tests/Selenium/Payments/IdealTest.js --timeout 60000",


### PR DESCRIPTION
- Switch to unique internal ID for creditcard token operations (fixes delete problem)
- Correctly handle notifications that arrive before initial transaction
- Add CreditCard One-Click Checkout selenium test. This test has requirements!
- Show actual remaining amount in dialog for backend operations (e.g. refund)
- Success messages are no longer sticky in backend
- Show PIA bank information above ThankYou block on checkout finish page
- Activate all selenium tests in runner config (except one-click checkout)