### PR TITLE
Update dependencies for php5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.6",
+    "symfony/options-resolver": "^3",
     "wirecard/payment-sdk-php": "^3.0.0",
     "php-http/guzzle5-adapter": ">=1.0.1",
     "guzzlehttp/psr7": ">=1.4.2"


### PR DESCRIPTION
- Require max version 3 for symfony/options-resolver