### PR TITLE
Add date of birth selection and additional T&C to Guaranteed Invoice

### DIFF
--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -299,11 +299,6 @@ class RatepayInvoicePayment extends Payment implements
             return false;
         }
 
-        // Check if consumer accepted TAC
-        if (! $this->getConfirmedTAC($sessionManager->getPaymentData())) {
-            return false;
-        }
-
         // Check if currency is accepted
         $currency = Shopware()->Shop()->getCurrency();
         if (! in_array($currency->getId(), $paymentConfig->getAcceptedCurrencies())) {

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -406,7 +406,7 @@ class RatepayInvoicePayment extends Payment implements
         $userMapper     = new UserMapper($userData, '', '');
         return [
             'method'   => $this->getName(),
-            'showForm' => ! $userMapper->getBirthday(),
+            'showBirthdayForm' => ! $userMapper->getBirthday(),
         ];
     }
 }

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -217,7 +217,7 @@ class RatepayInvoicePayment extends Payment implements
     {
         $accountHolderProperties = $accountHolder->mappedProperties();
 
-        // Date of bith is part of consumer data: check has already been done via checkDisplayRestrictions method
+        // Date of birth is part of consumer data: check has already been done via checkDisplayRestrictions method
         if (! empty($accountHolderProperties['date-of-birth'])) {
             return null;
         }
@@ -296,6 +296,12 @@ class RatepayInvoicePayment extends Payment implements
         // Check if consumer age is above 18, either via user data or payment data from checkout page
         $birthDay = $userMapper->getBirthday() ?: $this->getBirthdayFromPaymentData($sessionManager->getPaymentData());
         if ($birthDay && $this->isBelowAgeRestriction($birthDay)) {
+            return false;
+        }
+
+        // Check if consumer accepted TAC
+        $confirmedTAC = $this->getConfirmedTAC($sessionManager->getPaymentData());
+        if (!is_null($confirmedTAC) && !$this->getConfirmedTAC($sessionManager->getPaymentData())) {
             return false;
         }
 
@@ -382,6 +388,26 @@ class RatepayInvoicePayment extends Payment implements
             intval($paymentData['birthday']['day'])
         );
         return $birthDay;
+    }
+
+    /**
+     * @param array|null $paymentData
+     *
+     * @return bool
+     *
+     * @since 1.3.3
+     */
+    private function getConfirmedTAC($paymentData)
+    {
+        if (! isset($paymentData['tac'])) {
+            return null;
+        }
+
+        if ($paymentData['tac'] == "on") {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -300,8 +300,7 @@ class RatepayInvoicePayment extends Payment implements
         }
 
         // Check if consumer accepted TAC
-        $confirmedTAC = $this->getConfirmedTAC($sessionManager->getPaymentData());
-        if (!is_null($confirmedTAC) && !$this->getConfirmedTAC($sessionManager->getPaymentData())) {
+        if (! $this->getConfirmedTAC($sessionManager->getPaymentData())) {
             return false;
         }
 
@@ -399,15 +398,7 @@ class RatepayInvoicePayment extends Payment implements
      */
     private function getConfirmedTAC($paymentData)
     {
-        if (! isset($paymentData['tac'])) {
-            return null;
-        }
-
-        if ($paymentData['tac'] == "on") {
-            return true;
-        }
-
-        return false;
+        return isset($paymentData['tac']) && $paymentData['tac'] === 'on';
     }
 
     /**

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -385,18 +385,6 @@ class RatepayInvoicePayment extends Payment implements
     }
 
     /**
-     * @param array|null $paymentData
-     *
-     * @return bool
-     *
-     * @since 1.3.3
-     */
-    private function getConfirmedTAC($paymentData)
-    {
-        return isset($paymentData['tac']) && $paymentData['tac'] === 'on';
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getAdditionalViewAssignments(SessionManager $sessionManager)

--- a/Resources/languages/de_DE.json
+++ b/Resources/languages/de_DE.json
@@ -136,6 +136,7 @@
   "ptrid": "Provider Transaction Reference ID",
   "ratepayinvoice": "Garantierter Kauf auf Rechnung",
   "ratepayinvoice_fields_error": "Für die Nutzung dieses Zahlungmittels müssen Sie mindestens 18 Jahre alt sein.",
+  "ratepayinvoice_tac": "Hiermit bestätige ich, dass ich die <a href='https://www.wirecardbank.de/privacy-documents/datenschutzhinweis-fur-die-wirecard-zahlarten/' target='_blank'>Datenschutzhinweise</a> und zusätzliche <a href='https://www.wirecardbank.de/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>Geschäftsbedingungen</a> für Wirecard-Zahlarten zur Kenntnis genommen habe und mit deren Geltung einverstanden bin.",
   "redirect_text": "Sie werden weitergeleitet. Bitte warten.",
   "requestId": "Request ID",
   "response_type": "Source",

--- a/Resources/languages/en_US.json
+++ b/Resources/languages/en_US.json
@@ -136,6 +136,7 @@
   "ptrid": "Provider Transaction Reference ID",
   "ratepayinvoice": "Guaranteed Invoice",
   "ratepayinvoice_fields_error": "Minimum age to pay with Guaranteed Invoice: 18.",
+  "ratepayinvoice_tac": "I herewith confirm that I have read the <a href='https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/' target='_blank'>privacy notice</a> and <a href='https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>additional terms and conditions</a> for Wirecard payment types and that I accept their validity.",
   "redirect_text": "You are being redirected. Please wait.",
   "requestId": "Request ID",
   "response_type": "Source",

--- a/Resources/snippets/frontend/wirecard_elastic_engine/ratepay_invoice.ini
+++ b/Resources/snippets/frontend/wirecard_elastic_engine/ratepay_invoice.ini
@@ -1,6 +1,7 @@
 [de_DE]
 RatepayInvoiceFormHeader = "Garantierter Kauf auf Rechnung"
+RatepayTAC = "Hiermit bestätige ich, dass ich die <a href='https://www.wirecardbank.de/privacy-documents/datenschutzhinweis-fur-die-wirecard-zahlarten/' target='_blank'>Datenschutzhinweise</a> und zusätzliche <a href='https://www.wirecardbank.de/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>Geschäftsbedingungen</a> für Wirecard-Zahlarten zur Kenntnis genommen habe und mit deren Geltung einverstanden bin."
 
 [en_US]
 RatepayInvoiceFormHeader = "Guaranteed Invoice"
-
+RatepayTAC = "I herewith confirm that I have read the <a href='https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/' target='_blank'>privacy notice</a> and <a href='https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>additional terms and conditions</a> for Wirecard payment types and that I accept their validity."

--- a/Resources/snippets/frontend/wirecard_elastic_engine/ratepay_invoice.ini
+++ b/Resources/snippets/frontend/wirecard_elastic_engine/ratepay_invoice.ini
@@ -1,7 +1,8 @@
 [de_DE]
 RatepayInvoiceFormHeader = "Garantierter Kauf auf Rechnung"
-RatepayTAC = "Hiermit bestätige ich, dass ich die <a href='https://www.wirecardbank.de/privacy-documents/datenschutzhinweis-fur-die-wirecard-zahlarten/' target='_blank'>Datenschutzhinweise</a> und zusätzliche <a href='https://www.wirecardbank.de/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>Geschäftsbedingungen</a> für Wirecard-Zahlarten zur Kenntnis genommen habe und mit deren Geltung einverstanden bin."
+RatepayInvoiceTAC = "Hiermit bestätige ich, dass ich die <a href='https://www.wirecardbank.de/privacy-documents/datenschutzhinweis-fur-die-wirecard-zahlarten/' target='_blank'>Datenschutzhinweise</a> und zusätzliche <a href='https://www.wirecardbank.de/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>Geschäftsbedingungen</a> für Wirecard-Zahlarten zur Kenntnis genommen habe und mit deren Geltung einverstanden bin."
 
 [en_US]
 RatepayInvoiceFormHeader = "Guaranteed Invoice"
-RatepayTAC = "I herewith confirm that I have read the <a href='https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/' target='_blank'>privacy notice</a> and <a href='https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>additional terms and conditions</a> for Wirecard payment types and that I accept their validity."
+RatepayInvoiceTAC = "I herewith confirm that I have read the <a href='https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/' target='_blank'>privacy notice</a> and <a href='https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/' target='_blank'>additional terms and conditions</a> for Wirecard payment types and that I accept their validity."
+

--- a/Resources/snippets/frontend/wirecard_elastic_engine/ratepay_invoice.ini.tpl
+++ b/Resources/snippets/frontend/wirecard_elastic_engine/ratepay_invoice.ini.tpl
@@ -1,5 +1,6 @@
 @forlang
 [{{ locale }}]
 RatepayInvoiceFormHeader = "{{ strings.ratepayinvoice }}"
+RatepayInvoiceTAC = "{{ strings.ratepayinvoice_tac }}"
 
 @endforlang

--- a/Resources/views/frontend/_public/src/less/_modules/payments.less
+++ b/Resources/views/frontend/_public/src/less/_modules/payments.less
@@ -7,6 +7,10 @@
  */
 
 .wirecardee--additional-form-fields {
+    input[type="checkbox"] {
+        width: 15px !important;
+        margin-right: 10px;
+    }
     input {
         width: 100%;
         .unitize(margin-bottom, 10);

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -47,16 +47,18 @@
                     {if $wirecardElasticEngineViewAssignments.showBirthdayForm}
                         {include file="frontend/plugins/wirecard_elastic_engine/form/ratepay_invoice.tpl"}
                     {/if}
+                </div>
+            </div>
 
+            <div class="tos--panel panel has--border">
+                <div class="panel--body is--wide">
                     <ul class="list--checkbox list--unstyled">
                         <li class="block-group row--tos">
                             <span class="block column--checkbox">
                                 <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
                             </span>
                             <span class="block column--label">
-                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">
-                                    {s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}
-                                </label>
+                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">{s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}</label>
                             </span>
                         </li>
                     </ul>

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -55,7 +55,7 @@
                                     <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
                                 </span>
                                 <span class="block column--label">
-                                    <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">
+                                    <label for="wirecardee--tac" data-width="750">
                                         {s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}
                                     </label>
                                 </span>

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -47,21 +47,21 @@
                     {if $wirecardElasticEngineViewAssignments.showBirthdayForm}
                         {include file="frontend/plugins/wirecard_elastic_engine/form/ratepay_invoice.tpl"}
                     {/if}
-                </div>
-            </div>
 
-            <div class="tos--panel panel has--border">
-                <div class="panel--body is--wide">
-                    <ul class="list--checkbox list--unstyled">
-                        <li class="block-group row--tos">
-                            <span class="block column--checkbox">
-                                <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
-                            </span>
-                            <span class="block column--label">
-                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">{s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}</label>
-                            </span>
-                        </li>
-                    </ul>
+                    <div class="tos--panel panel">
+                        <ul class="list--checkbox list--unstyled">
+                            <li class="block-group row--tos">
+                                <span class="block column--checkbox">
+                                    <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
+                                </span>
+                                <span class="block column--label">
+                                    <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">
+                                        {s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}
+                                    </label>
+                                </span>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
 

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -49,6 +49,20 @@
                     </div>
                 </div>
             {/if}
+            <div class="tos--panel panel has--border">
+                <div class="panel--body is--wide">
+                    <ul class="list--checkbox list--unstyled">
+                        <li class="block-group row--tos">
+                            <span class="block column--checkbox">
+                                <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
+                            </span>
+                            <span class="block column--label">
+                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">{s name="RatepayTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}</label>
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
             <script language="JavaScript">
                 var di = { t: "{$wirecardElasticEngineDeviceFingerprintId}", v: "WDWL", l: "Checkout" };
             </script>

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -57,7 +57,7 @@
                                 <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
                             </span>
                             <span class="block column--label">
-                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">{s name="RatepayTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}</label>
+                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">{s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}</label>
                             </span>
                         </li>
                     </ul>

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -39,30 +39,30 @@
                 </div>
             </div>
         {elseif $wirecardElasticEngineViewAssignments.method == 'wirecard_elastic_engine_ratepay_invoice'}
-            {if $wirecardElasticEngineViewAssignments.showForm}
-                <div class="panel has--border wirecardee--additional-form-fields">
-                    <div class="panel--title primary is--underline">
-                        {s name="RatepayInvoiceFormHeader" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}
-                    </div>
-                    <div class="panel--body is--wide">
-                        {include file="frontend/plugins/wirecard_elastic_engine/form/ratepay_invoice.tpl"}
-                    </div>
+            <div class="panel has--border wirecardee--additional-form-fields">
+                <div class="panel--title primary is--underline">
+                    {s name="RatepayInvoiceFormHeader" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}
                 </div>
-            {/if}
-            <div class="tos--panel panel has--border">
                 <div class="panel--body is--wide">
+                    {if $wirecardElasticEngineViewAssignments.showBirthdayForm}
+                        {include file="frontend/plugins/wirecard_elastic_engine/form/ratepay_invoice.tpl"}
+                    {/if}
+
                     <ul class="list--checkbox list--unstyled">
                         <li class="block-group row--tos">
                             <span class="block column--checkbox">
                                 <input id="wirecardee--tac" type="checkbox" name="wirecardElasticEngine[tac]" required="required" aria-required="true" data-invalid-tos-jump="true" />
                             </span>
                             <span class="block column--label">
-                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">{s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}</label>
+                                <label for="wirecardElasticEngine[tac]" data-modalbox="true" data-height="500" data-width="750">
+                                    {s name="RatepayInvoiceTAC" namespace="frontend/wirecard_elastic_engine/ratepay_invoice"}{/s}
+                                </label>
                             </span>
                         </li>
                     </ul>
                 </div>
             </div>
+
             <script language="JavaScript">
                 var di = { t: "{$wirecardElasticEngineDeviceFingerprintId}", v: "WDWL", l: "Checkout" };
             </script>

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -256,7 +256,6 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
     public function testProcessPaymentWithoutConsumerBirthday()
     {
         $this->assertInstanceOf(ProcessPaymentInterface::class, $this->payment);
-
         $orderSummary = $this->createMock(OrderSummary::class);
         $orderSummary->method('getAmount')->willReturn(new Amount(0.0, 'EUR'));
         $orderSummary->expects($this->atLeastOnce())->method('getPaymentUniqueId')->willReturn('123test');
@@ -344,12 +343,27 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
     public function testCheckDisplayRestrictions()
     {
         $sessionManager = $this->createMock(SessionManager::class);
+        $sessionManager->method('getPaymentData')
+             ->willReturn(['tac' => 'on']);
 
         $userMapper = $this->createMock(UserMapper::class);
         $userMapper->method('getBillingAddress')->willReturn(['countryId' => 2]);
         $userMapper->method('getShippingAddress')->willReturn(['countryId' => 2]);
         $userMapper->method('getBirthday')->willReturn(new \DateTime('2000-01-01'));
         $this->assertTrue($this->payment->checkDisplayRestrictions($userMapper, $sessionManager));
+    }
+
+    public function testCheckDisplayRestrictionsWithoutTAC()
+    {
+        $sessionManager = $this->createMock(SessionManager::class);
+        $sessionManager->method('getPaymentData')
+             ->willReturn(['tac' => 'off']);
+
+        $userMapper = $this->createMock(UserMapper::class);
+        $userMapper->method('getBillingAddress')->willReturn(['countryId' => 2]);
+        $userMapper->method('getShippingAddress')->willReturn(['countryId' => 2]);
+        $userMapper->method('getBirthday')->willReturn(new \DateTime('2000-01-01'));
+        $this->assertFalse($this->payment->checkDisplayRestrictions($userMapper, $sessionManager));
     }
 
     public function testGetAdditionalViewAssignments()

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -343,25 +343,12 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
     public function testCheckDisplayRestrictions()
     {
         $sessionManager = $this->createMock(SessionManager::class);
-        $sessionManager->method('getPaymentData')->willReturn(['tac' => 'on']);
 
         $userMapper = $this->createMock(UserMapper::class);
         $userMapper->method('getBillingAddress')->willReturn(['countryId' => 2]);
         $userMapper->method('getShippingAddress')->willReturn(['countryId' => 2]);
         $userMapper->method('getBirthday')->willReturn(new \DateTime('2000-01-01'));
         $this->assertTrue($this->payment->checkDisplayRestrictions($userMapper, $sessionManager));
-    }
-
-    public function testCheckDisplayRestrictionsWithoutTAC()
-    {
-        $sessionManager = $this->createMock(SessionManager::class);
-        $sessionManager->method('getPaymentData')->willReturn(['tac' => 'off']);
-
-        $userMapper = $this->createMock(UserMapper::class);
-        $userMapper->method('getBillingAddress')->willReturn(['countryId' => 2]);
-        $userMapper->method('getShippingAddress')->willReturn(['countryId' => 2]);
-        $userMapper->method('getBirthday')->willReturn(new \DateTime('2000-01-01'));
-        $this->assertFalse($this->payment->checkDisplayRestrictions($userMapper, $sessionManager));
     }
 
     public function testGetAdditionalViewAssignments()

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -343,8 +343,7 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
     public function testCheckDisplayRestrictions()
     {
         $sessionManager = $this->createMock(SessionManager::class);
-        $sessionManager->method('getPaymentData')
-             ->willReturn(['tac' => 'on']);
+        $sessionManager->method('getPaymentData')->willReturn(['tac' => 'on']);
 
         $userMapper = $this->createMock(UserMapper::class);
         $userMapper->method('getBillingAddress')->willReturn(['countryId' => 2]);
@@ -356,8 +355,7 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
     public function testCheckDisplayRestrictionsWithoutTAC()
     {
         $sessionManager = $this->createMock(SessionManager::class);
-        $sessionManager->method('getPaymentData')
-             ->willReturn(['tac' => 'off']);
+        $sessionManager->method('getPaymentData')->willReturn(['tac' => 'off']);
 
         $userMapper = $this->createMock(UserMapper::class);
         $userMapper->method('getBillingAddress')->willReturn(['countryId' => 2]);

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -371,7 +371,7 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
         $this->assertInstanceOf(AdditionalViewAssignmentsInterface::class, $this->payment);
         $this->assertEquals([
             'method'   => 'wirecard_elastic_engine_ratepay_invoice',
-            'showForm' => true,
+            'showBirthdayForm' => true,
         ], $this->payment->getAdditionalViewAssignments($sessionManager));
     }
 }


### PR DESCRIPTION
### This PR
- Adds a date picker for the date of birth to the order confirmation page when the Guaranteed Invoice payment method is selected and when the customer does not have a date of birth entered in their account
- Adds additional terms & conditions with a checkbox for the Guaranteed Invoice payment method