### PR TITLE
Guaranteed Invoice phone number field restriction

### DIFF
--- a/Components/Payments/Payment.php
+++ b/Components/Payments/Payment.php
@@ -199,7 +199,7 @@ abstract class Payment implements PaymentInterface
      *
      * @since 1.3.4
      */
-    public function validateActivation(array $requestBody)
+    public function validateUpdate(array $requestBody)
     {
     }
 }

--- a/Components/Payments/Payment.php
+++ b/Components/Payments/Payment.php
@@ -15,6 +15,7 @@ use Shopware\Components\Routing\RouterInterface;
 use Shopware\Models\Order\Order;
 use Shopware\Models\Shop\Shop;
 use Shopware_Components_Config;
+use Shopware_Components_Snippet_Manager;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Wirecard\PaymentSdk\Config\Config;
 use WirecardElasticEngine\Exception\UnknownTransactionTypeException;
@@ -65,11 +66,17 @@ abstract class Payment implements PaymentInterface
     protected $eventManager;
 
     /**
-     * @param EntityManagerInterface      $em
-     * @param Shopware_Components_Config  $shopwareConfig
-     * @param InstallerService            $installerService
-     * @param RouterInterface             $router
-     * @param \Enlight_Event_EventManager $eventManager
+     * @var Shopware_Components_Snippet_Manager
+     */
+    protected $snippetManager;
+
+    /**
+     * @param EntityManagerInterface               $em
+     * @param Shopware_Components_Config           $shopwareConfig
+     * @param InstallerService                     $installerService
+     * @param RouterInterface                      $router
+     * @param \Enlight_Event_EventManager          $eventManager
+     * @param Shopware_Components_Snippet_Manager  $snippetManager
      *
      * @since 1.0.0
      */
@@ -78,13 +85,15 @@ abstract class Payment implements PaymentInterface
         Shopware_Components_Config $shopwareConfig,
         InstallerService $installerService,
         RouterInterface $router,
-        \Enlight_Event_EventManager $eventManager
+        \Enlight_Event_EventManager $eventManager,
+        Shopware_Components_Snippet_Manager $snippetManager
     ) {
         $this->em               = $em;
         $this->shopwareConfig   = $shopwareConfig;
         $this->installerService = $installerService;
         $this->router           = $router;
         $this->eventManager     = $eventManager;
+        $this->snippetManager   = $snippetManager;
     }
 
     /**

--- a/Components/Payments/Payment.php
+++ b/Components/Payments/Payment.php
@@ -184,4 +184,13 @@ abstract class Payment implements PaymentInterface
     {
         return $this->shopwareConfig->getByNamespace(WirecardElasticEngine::NAME, $prefix . $name);
     }
+
+    /**
+     * @param array $requestBody
+     *
+     * @since 1.3.4
+     */
+    public function validateActivation(array $requestBody)
+    {
+    }
 }

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -408,7 +408,8 @@ class RatepayInvoicePayment extends Payment implements
 
             throw new \Exception($snippets->get(
                 'PaymentMethodRequiresPhoneNumber',
-                'This payment method requires the phone number field to be activated for Login / Registration. You can activate it in the Basic Settings.'
+                'This payment method requires the phone number field to be activated for Login / Registration. ' .
+                'You can activate it in the Basic Settings.'
             ));
         }
     }

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -397,4 +397,14 @@ class RatepayInvoicePayment extends Payment implements
             'showForm' => ! $userMapper->getBirthday(),
         ];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateActivation(array $requestBody)
+    {
+        if ($requestBody['active'] && ! $this->shopwareConfig->get('showphonenumberfield')) {
+            throw new \Exception('This payment method requires the phone number field to be activated for customer registration. You can activate it in the Basic Settings.');
+        }
+    }
 }

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -401,7 +401,7 @@ class RatepayInvoicePayment extends Payment implements
     /**
      * {@inheritdoc}
      */
-    public function validateActivation(array $requestBody)
+    public function validateUpdate(array $requestBody)
     {
         if ($requestBody['active'] && ! $this->shopwareConfig->get('showphonenumberfield')) {
             $snippets = $this->snippetManager->getNamespace('backend/wirecard_elastic_engine/common');

--- a/Components/Payments/RatepayInvoicePayment.php
+++ b/Components/Payments/RatepayInvoicePayment.php
@@ -404,7 +404,12 @@ class RatepayInvoicePayment extends Payment implements
     public function validateActivation(array $requestBody)
     {
         if ($requestBody['active'] && ! $this->shopwareConfig->get('showphonenumberfield')) {
-            throw new \Exception('This payment method requires the phone number field to be activated for customer registration. You can activate it in the Basic Settings.');
+            $snippets = $this->snippetManager->getNamespace('backend/wirecard_elastic_engine/common');
+
+            throw new \Exception($snippets->get(
+                'PaymentMethodRequiresPhoneNumber',
+                'This payment method requires the phone number field to be activated for Login / Registration. You can activate it in the Basic Settings.'
+            ));
         }
     }
 }

--- a/Components/Services/PaymentFactory.php
+++ b/Components/Services/PaymentFactory.php
@@ -64,11 +64,17 @@ class PaymentFactory
     protected $eventManager;
 
     /**
-     * @param EntityManagerInterface      $em
-     * @param \Shopware_Components_Config $shopwareConfig
-     * @param InstallerService            $installerService
-     * @param RouterInterface             $router
-     * @param \Enlight_Event_EventManager $eventManager
+     * @var \Shopware_Components_Snippet_Manager
+     */
+    protected $snippetManager;
+
+    /**
+     * @param EntityManagerInterface               $em
+     * @param \Shopware_Components_Config          $shopwareConfig
+     * @param InstallerService                     $installerService
+     * @param RouterInterface                      $router
+     * @param \Enlight_Event_EventManager          $eventManager
+     * @param \Shopware_Components_Snippet_Manager $snippetManager
      *
      * @since 1.0.0
      */
@@ -77,13 +83,15 @@ class PaymentFactory
         \Shopware_Components_Config $shopwareConfig,
         InstallerService $installerService,
         RouterInterface $router,
-        \Enlight_Event_EventManager $eventManager
+        \Enlight_Event_EventManager $eventManager,
+        \Shopware_Components_Snippet_Manager $snippetManager
     ) {
         $this->em               = $em;
         $this->shopwareConfig   = $shopwareConfig;
         $this->installerService = $installerService;
         $this->router           = $router;
         $this->eventManager     = $eventManager;
+        $this->snippetManager   = $snippetManager;
     }
 
     /**
@@ -106,7 +114,8 @@ class PaymentFactory
             $this->shopwareConfig,
             $this->installerService,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Resources/languages/de_DE.json
+++ b/Resources/languages/de_DE.json
@@ -80,6 +80,7 @@
   "error_credentials": "Test fehlgeschlagen. Überprüfen Sie Ihre Zugangsdaten.",
   "error_email": "E-Mail-Versand fehlgeschlagen.",
   "error_no_transaction": "Es wurde keine Transaktion gefunden.",
+  "ratepayinvoice_fields_phone_error": "Für diese Zahlungsart muss das Telefonnummer-Feld im Bereich Anmeldung / Registrierung aktiviert sein. Sie können es in den Grundeinstellungen aktivieren.",
   "fill_out_fields_error": "Bitte füllen Sie alle rot markierten Felder aus.",
   "first_name_input": "Vorname",
   "heading_title": "Wirecard",

--- a/Resources/languages/en_US.json
+++ b/Resources/languages/en_US.json
@@ -135,6 +135,7 @@
   "poi_pia": "Payment On Invoice / Payment In Advance",
   "ptrid": "Provider Transaction Reference ID",
   "ratepayinvoice": "Guaranteed Invoice",
+  "ratepayinvoice_fields_phone_error": "This payment method requires the phone number field to be activated for Login / Registration. You can activate it in the Basic Settings.",
   "ratepayinvoice_fields_error": "Minimum age to pay with Guaranteed Invoice: 18.",
   "redirect_text": "You are being redirected. Please wait.",
   "requestId": "Request ID",

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="shopware_plugininstaller.plugin_manager"/>
             <argument type="service" id="router"/>
             <argument type="service" id="events"/>
+            <argument type="service" id="snippets"/>
         </service>
         <service id="wirecard_elastic_engine.transaction_manager"
                  class="WirecardElasticEngine\Components\Services\TransactionManager">

--- a/Resources/snippets/backend/wirecard_elastic_engine/common.ini
+++ b/Resources/snippets/backend/wirecard_elastic_engine/common.ini
@@ -3,10 +3,12 @@ TestCredentialsSuccessful = "Die Konfigurationseinstellungen wurden erfolgreich 
 TestCredentialsFailed = "Test fehlgeschlagen. Überprüfen Sie Ihre Zugangsdaten."
 InvalidTestCredentialsURL = "Test fehlgeschlagen. Ungültiges Adressformat (z. B. https://api.wirecard.com)."
 PaymentNotificationMailSubject = "Zahlungsbestätigung erhalten"
+PaymentMethodRequiresPhoneNumber = "Für diese Zahlungsart muss das Telefonnummer-Feld im Bereich Anmeldung / Registrierung aktiviert sein. Sie können es in den Grundeinstellungen aktivieren."
 
 [en_US]
 TestCredentialsSuccessful = "Merchant configuration was successfully tested."
 TestCredentialsFailed = "Test failed, please check your credentials."
 InvalidTestCredentialsURL = "Test failed. Address format is invalid (e.g. https://api.wirecard.com)."
 PaymentNotificationMailSubject = "Payment notification received"
+PaymentMethodRequiresPhoneNumber = "This payment method requires the phone number field to be activated for Login / Registration. You can activate it in the Basic Settings."
 

--- a/Resources/snippets/backend/wirecard_elastic_engine/common.ini.tpl
+++ b/Resources/snippets/backend/wirecard_elastic_engine/common.ini.tpl
@@ -4,5 +4,6 @@ TestCredentialsSuccessful = "{{ strings.success_credentials }}"
 TestCredentialsFailed = "{{ strings.error_credentials }}"
 InvalidTestCredentialsURL = "{{ strings.wrong_url_format }}"
 PaymentNotificationMailSubject = "{{ strings.payment_notification_received }}"
+PaymentMethodRequiresPhoneNumber = "{{ strings.ratepayinvoice_fields_phone_error }}"
 
 @endforlang

--- a/Subscriber/BackendSubscriber.php
+++ b/Subscriber/BackendSubscriber.php
@@ -97,7 +97,7 @@ class BackendSubscriber implements SubscriberInterface
             $paymentInstance = $paymentFactory->create($requestBody['name']);
 
             try {
-                $paymentInstance->validateActivation($requestBody);
+                $paymentInstance->validateUpdate($requestBody);
             } catch (\Exception $e) {
                 $payment->View()->assign([
                     'success'  => false,

--- a/Tests/Functional/Components/Payments/AlipayPaymentTest.php
+++ b/Tests/Functional/Components/Payments/AlipayPaymentTest.php
@@ -41,24 +41,29 @@ class AlipayPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var AlipayPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new AlipayPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/CreditCardPaymentTest.php
+++ b/Tests/Functional/Components/Payments/CreditCardPaymentTest.php
@@ -41,24 +41,29 @@ class CreditCardPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var CreditCardPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new CreditCardPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/IdealPaymentTest.php
+++ b/Tests/Functional/Components/Payments/IdealPaymentTest.php
@@ -42,24 +42,29 @@ class IdealPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var IdealPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new IdealPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/MasterpassPaymentTest.php
+++ b/Tests/Functional/Components/Payments/MasterpassPaymentTest.php
@@ -41,24 +41,29 @@ class MasterpassPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var MasterpassPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new MasterpassPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/PaymentInAdvancePaymentTest.php
+++ b/Tests/Functional/Components/Payments/PaymentInAdvancePaymentTest.php
@@ -41,24 +41,29 @@ class PaymentInAdvancePaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var PaymentInAdvancePayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new PaymentInAdvancePayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/PaymentOnInvoicePaymentTest.php
+++ b/Tests/Functional/Components/Payments/PaymentOnInvoicePaymentTest.php
@@ -41,24 +41,29 @@ class PaymentOnInvoicePaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var PaymentOnInvoicePayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new PaymentOnInvoicePayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/PaypalPaymentTest.php
+++ b/Tests/Functional/Components/Payments/PaypalPaymentTest.php
@@ -41,24 +41,29 @@ class PaypalPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var PaypalPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new PaypalPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Functional/Components/Payments/RatepayInvoicePaymentTest.php
@@ -41,24 +41,29 @@ class RatepayInvoicePaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var RatepayInvoicePayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new RatepayInvoicePayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/SepaPaymentTest.php
+++ b/Tests/Functional/Components/Payments/SepaPaymentTest.php
@@ -44,24 +44,29 @@ class SepaPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var SepaPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new SepaPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/SofortPaymentTest.php
+++ b/Tests/Functional/Components/Payments/SofortPaymentTest.php
@@ -42,24 +42,29 @@ class SofortPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var SofortPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new SofortPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Functional/Components/Payments/UnionpayInternationalPaymentTest.php
+++ b/Tests/Functional/Components/Payments/UnionpayInternationalPaymentTest.php
@@ -41,24 +41,29 @@ class UnionpayInternationalPaymentTest extends TestCase
     /** @var \Enlight_Event_EventManager $config */
     private $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager $config */
+    private $snippetManager;
+
     /** @var UnionpayInternationalPayment */
     protected $payment;
 
     public function setUp()
     {
-        $this->container    = \Shopware()->Container();
-        $this->em           = $this->container->get('models');
-        $this->config       = $this->container->get('config');
-        $this->installer    = $this->container->get('shopware_plugininstaller.plugin_manager');
-        $this->router       = $this->container->get('router');
-        $this->eventManager = $this->container->get('events');
+        $this->container      = \Shopware()->Container();
+        $this->em             = $this->container->get('models');
+        $this->config         = $this->container->get('config');
+        $this->installer      = $this->container->get('shopware_plugininstaller.plugin_manager');
+        $this->router         = $this->container->get('router');
+        $this->eventManager   = $this->container->get('events');
+        $this->snippetManager = $this->container->get('snippets');
 
         $this->payment = new UnionpayInternationalPayment(
             $this->em,
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Unit/Components/Payments/AbstractPaymentTest.php
+++ b/Tests/Unit/Components/Payments/AbstractPaymentTest.php
@@ -28,6 +28,7 @@ class AbstractPaymentTest extends PaymentTestCase
             $this->installer,
             $this->router,
             $this->eventManager,
+            $this->snippetManager,
         ], 'FooPayment');
     }
 

--- a/Tests/Unit/Components/Payments/AlipayPaymentTest.php
+++ b/Tests/Unit/Components/Payments/AlipayPaymentTest.php
@@ -46,7 +46,8 @@ class AlipayPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -147,10 +148,24 @@ class AlipayPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineAlipayTransactionType', null, 'pay'],
         ]);
-        $payment = new AlipayPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new AlipayPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
-        $payment = new AlipayPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new AlipayPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/CreditCardPaymentTest.php
+++ b/Tests/Unit/Components/Payments/CreditCardPaymentTest.php
@@ -61,7 +61,8 @@ class CreditCardPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -146,14 +147,28 @@ class CreditCardPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEnginePaypalTransactionType', null, 'pay'],
         ]);
-        $payment = new PaypalPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new PaypalPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
         $config = $this->createMock(\Shopware_Components_Config::class);
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEnginePaypalTransactionType', null, 'reserve'],
         ]);
-        $payment = new PaypalPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new PaypalPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/EpsPaymentTest.php
+++ b/Tests/Unit/Components/Payments/EpsPaymentTest.php
@@ -48,7 +48,8 @@ class EpsPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -129,10 +130,24 @@ class EpsPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineEpsTransactionType', null, 'pay'],
         ]);
-        $payment = new EpsPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new EpsPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
-        $payment = new EpsPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new EpsPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/IdealPaymentTest.php
+++ b/Tests/Unit/Components/Payments/IdealPaymentTest.php
@@ -51,7 +51,8 @@ class IdealPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -175,10 +176,24 @@ class IdealPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineIdealTransactionType', null, 'pay'],
         ]);
-        $payment = new IdealPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new IdealPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
-        $payment = new IdealPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new IdealPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/MasterpassPaymentTest.php
+++ b/Tests/Unit/Components/Payments/MasterpassPaymentTest.php
@@ -43,7 +43,8 @@ class MasterpassPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -153,14 +154,28 @@ class MasterpassPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineMasterpassTransactionType', null, 'pay'],
         ]);
-        $payment = new MasterpassPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new MasterpassPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
         $config = $this->createMock(\Shopware_Components_Config::class);
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineMasterpassTransactionType', null, 'reserve'],
         ]);
-        $payment = new MasterpassPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new MasterpassPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }
 }

--- a/Tests/Unit/Components/Payments/PaymentInAdvancePaymentTest.php
+++ b/Tests/Unit/Components/Payments/PaymentInAdvancePaymentTest.php
@@ -49,7 +49,8 @@ class PaymentInAdvancePaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -145,7 +146,8 @@ class PaymentInAdvancePaymentTest extends PaymentTestCase
             $config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }

--- a/Tests/Unit/Components/Payments/PaymentOnInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/PaymentOnInvoicePaymentTest.php
@@ -45,7 +45,8 @@ class PaymentOnInvoicePaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -141,7 +142,8 @@ class PaymentOnInvoicePaymentTest extends PaymentTestCase
             $config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }

--- a/Tests/Unit/Components/Payments/PaypalPaymentTest.php
+++ b/Tests/Unit/Components/Payments/PaypalPaymentTest.php
@@ -48,7 +48,8 @@ class PaypalPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -129,14 +130,28 @@ class PaypalPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEnginePaypalTransactionType', null, 'pay'],
         ]);
-        $payment = new PaypalPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new PaypalPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
         $config = $this->createMock(\Shopware_Components_Config::class);
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEnginePaypalTransactionType', null, 'reserve'],
         ]);
-        $payment = new PaypalPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new PaypalPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -363,4 +363,19 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
             'showForm' => true,
         ], $this->payment->getAdditionalViewAssignments($sessionManager));
     }
+
+    public function testValidateActivation()
+    {
+        $this->expectException(\Exception::class);
+
+        $snippets = $this->createMock(\Enlight_Components_Snippet_Namespace::class);
+
+        $this->config->method('get')->with('showphonenumberfield')->willReturn(false);
+        $this->snippetManager->method('getNamespace')->willReturn($snippets);
+
+        $this->payment->validateActivation([
+            'name'   => 'wirecard_elastic_engine_ratepay_invoice',
+            'active' => true,
+        ]);
+    }
 }

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -364,7 +364,7 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
         ], $this->payment->getAdditionalViewAssignments($sessionManager));
     }
 
-    public function testValidateActivation()
+    public function testValidateUpdate()
     {
         $this->expectException(\Exception::class);
 
@@ -373,7 +373,7 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
         $this->config->method('get')->with('showphonenumberfield')->willReturn(false);
         $this->snippetManager->method('getNamespace')->willReturn($snippets);
 
-        $this->payment->validateActivation([
+        $this->payment->validateUpdate([
             'name'   => 'wirecard_elastic_engine_ratepay_invoice',
             'active' => true,
         ]);

--- a/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
+++ b/Tests/Unit/Components/Payments/RatepayInvoicePaymentTest.php
@@ -60,7 +60,8 @@ class RatepayInvoicePaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 

--- a/Tests/Unit/Components/Payments/SepaPaymentTest.php
+++ b/Tests/Unit/Components/Payments/SepaPaymentTest.php
@@ -52,7 +52,8 @@ class SepaPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -179,14 +180,28 @@ class SepaPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineSepaTransactionType', null, 'pay'],
         ]);
-        $payment = new SepaPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new SepaPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
         $config = $this->createMock(\Shopware_Components_Config::class);
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineSepaTransactionType', null, 'reserve'],
         ]);
-        $payment = new SepaPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new SepaPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/SofortPaymentTest.php
+++ b/Tests/Unit/Components/Payments/SofortPaymentTest.php
@@ -48,7 +48,8 @@ class SofortPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -181,10 +182,24 @@ class SofortPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEngineSofortTransactionType', null, 'pay'],
         ]);
-        $payment = new SofortPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new SofortPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
-        $payment = new SofortPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new SofortPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Payments/UnionpayInternationalPaymentTest.php
+++ b/Tests/Unit/Components/Payments/UnionpayInternationalPaymentTest.php
@@ -50,7 +50,8 @@ class UnionpayInternationalPaymentTest extends PaymentTestCase
             $this->config,
             $this->installer,
             $this->router,
-            $this->eventManager
+            $this->eventManager,
+            $this->snippetManager
         );
     }
 
@@ -132,14 +133,28 @@ class UnionpayInternationalPaymentTest extends PaymentTestCase
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEnginePaypalTransactionType', null, 'pay'],
         ]);
-        $payment = new PaypalPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new PaypalPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('purchase', $payment->getTransactionType());
 
         $config = $this->createMock(\Shopware_Components_Config::class);
         $config->method('getByNamespace')->willReturnMap([
             [WirecardElasticEngine::NAME, 'wirecardElasticEnginePaypalTransactionType', null, 'reserve'],
         ]);
-        $payment = new PaypalPayment($this->em, $config, $this->installer, $this->router, $this->eventManager);
+        $payment = new PaypalPayment(
+            $this->em,
+            $config,
+            $this->installer,
+            $this->router,
+            $this->eventManager,
+            $this->snippetManager
+        );
         $this->assertEquals('authorization', $payment->getTransactionType());
     }
 

--- a/Tests/Unit/Components/Services/PaymentFactoryTest.php
+++ b/Tests/Unit/Components/Services/PaymentFactoryTest.php
@@ -32,15 +32,17 @@ class PaymentFactoryTest extends TestCase
         /** @var \Shopware_Components_Config|\PHPUnit_Framework_MockObject_MockObject $config */
         /** @var InstallerService|\PHPUnit_Framework_MockObject_MockObject $installer */
         /** @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject $router */
-        /** @var \Enlight_Event_EventManager|\PHPUnit_Framework_MockObject_MockObject $router */
+        /** @var \Enlight_Event_EventManager|\PHPUnit_Framework_MockObject_MockObject $eventManager */
+        /** @var \Shopware_Components_Snippet_Manager|\PHPUnit_Framework_MockObject_MockObject $snippetManager */
 
-        $em           = $this->createMock(EntityManagerInterface::class);
-        $config       = $this->createMock(\Shopware_Components_Config::class);
-        $installer    = $this->createMock(InstallerService::class);
-        $router       = $this->createMock(RouterInterface::class);
-        $eventManager = $this->createMock(\Enlight_Event_EventManager::class);
+        $em             = $this->createMock(EntityManagerInterface::class);
+        $config         = $this->createMock(\Shopware_Components_Config::class);
+        $installer      = $this->createMock(InstallerService::class);
+        $router         = $this->createMock(RouterInterface::class);
+        $eventManager   = $this->createMock(\Enlight_Event_EventManager::class);
+        $snippetManager = $this->createMock(\Shopware_Components_Snippet_Manager::class);
 
-        $this->factory = new PaymentFactory($em, $config, $installer, $router, $eventManager);
+        $this->factory  = new PaymentFactory($em, $config, $installer, $router, $eventManager, $snippetManager);
     }
 
     public function testPaypalInstance()

--- a/Tests/Unit/PaymentTestCase.php
+++ b/Tests/Unit/PaymentTestCase.php
@@ -32,14 +32,18 @@ abstract class PaymentTestCase extends \PHPUnit_Framework_TestCase
     /** @var \Enlight_Event_EventManager|\PHPUnit_Framework_MockObject_MockObject */
     protected $eventManager;
 
+    /** @var \Shopware_Components_Snippet_Manager|\PHPUnit_Framework_MockObject_MockObject */
+    protected $snippetManager;
+
     public function setUp()
     {
         parent::setUp();
-        $this->em           = $this->createMock(EntityManagerInterface::class);
-        $this->config       = $this->createMock(\Shopware_Components_Config::class);
-        $this->installer    = $this->createMock(InstallerService::class);
-        $this->router       = $this->createMock(RouterInterface::class);
-        $this->eventManager = $this->createMock(\Enlight_Event_EventManager::class);
+        $this->em             = $this->createMock(EntityManagerInterface::class);
+        $this->config         = $this->createMock(\Shopware_Components_Config::class);
+        $this->installer      = $this->createMock(InstallerService::class);
+        $this->router         = $this->createMock(RouterInterface::class);
+        $this->eventManager   = $this->createMock(\Enlight_Event_EventManager::class);
+        $this->snippetManager = $this->createMock(\Shopware_Components_Snippet_Manager::class);
 
         $plugin = $this->createMock(Plugin::class);
         $plugin->method('getName')->willReturn(WirecardElasticEngine::NAME);

--- a/Tests/Unit/Subscriber/BackendSubscriberTest.php
+++ b/Tests/Unit/Subscriber/BackendSubscriberTest.php
@@ -18,7 +18,8 @@ class BackendSubscriberTest extends TestCase
     {
         $this->assertEquals([
             'Enlight_Controller_Action_PostDispatchSecure_Backend_Order' => 'onOrderPostDispatch',
-            'Enlight_Controller_Action_PostDispatchSecure_Backend_Index' => 'onLoadBackendIndex'
+            'Enlight_Controller_Action_PostDispatchSecure_Backend_Index' => 'onLoadBackendIndex',
+            'Enlight_Controller_Action_Backend_Payment_UpdatePayments'   => 'onUpdatePayments',
         ], BackendSubscriber::getSubscribedEvents());
     }
 

--- a/Tests/Unit/Subscriber/BackendSubscriberTest.php
+++ b/Tests/Unit/Subscriber/BackendSubscriberTest.php
@@ -98,7 +98,7 @@ class BackendSubscriberTest extends TestCase
         ]));
 
         $paymentInstance = $this->createMock(RatepayInvoicePayment::class);
-        $paymentInstance->expects($this->once())->method('validateActivation')->willThrowException(new \Exception());
+        $paymentInstance->expects($this->once())->method('validateUpdate')->willThrowException(new \Exception());
 
         $paymentFactory = $this->createMock(PaymentFactory::class);
         $paymentFactory->expects($this->once())->method('isSupportedPayment')->willReturn(true);

--- a/Tests/Unit/WirecardElasticEngineTest.php
+++ b/Tests/Unit/WirecardElasticEngineTest.php
@@ -23,7 +23,7 @@ class WirecardElasticEngineTest extends TestCase
 {
     public function testPlugin()
     {
-        $plugin = new WirecardElasticEngine(true);
+        $plugin = new WirecardElasticEngine(true, true);
         $this->assertInstanceOf(Plugin::class, $plugin);
         $this->assertTrue($plugin->isActive());
     }
@@ -36,6 +36,7 @@ class WirecardElasticEngineTest extends TestCase
             'shopware_plugininstaller.plugin_manager' => $this->createMock(InstallerService::class),
             'router'                                  => $this->createMock(RouterInterface::class),
             'events'                                  => $this->createMock(\Enlight_Event_EventManager::class),
+            'snippets'                                => $this->createMock(\Shopware_Components_Snippet_Manager::class),
         ];
         $map      = [];
         foreach ($services as $name => $service) {
@@ -46,7 +47,7 @@ class WirecardElasticEngineTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')->willReturnMap($map);
 
-        $plugin = new WirecardElasticEngine(true);
+        $plugin = new WirecardElasticEngine(true, true);
         $plugin->setContainer($container);
         $this->assertInstanceOf(Plugin::class, $plugin);
         $payments = $plugin->getSupportedPayments();

--- a/WirecardElasticEngine.php
+++ b/WirecardElasticEngine.php
@@ -209,7 +209,8 @@ class WirecardElasticEngine extends Plugin
             $this->container->get('config'),
             $this->container->get('shopware_plugininstaller.plugin_manager'),
             $this->container->get('router'),
-            $this->container->get('events')
+            $this->container->get('events'),
+            $this->container->get('snippets')
         );
         return $paymentFactory->getSupportedPayments();
     }


### PR DESCRIPTION
### This PR

* Prevents activation of the **Guaranteed Invoice** payment method if the phone number field is not activated for login / registration in Shopware

### Notes

* A new `validateUpdate` method was added for all payment methods; throwing an Exception within this method will prevent the payment method from being updated, showing the Exception message to the user

### How to test

* Login to the backend
* Go to **Configuration** → **Basic Settings** → **Frontend** → **Login / Registration**
* Make sure the setting for "Show phone number field" is set to "No"
* Go to **Configuration** → **Payment methods** → **Wirecard Garantierter Kauf auf Rechnung**
* Tick the "Active" checkbox and hit "Save" – a notice  should be displayed explaining that the phone number field is required
* Go to **Configuration** → **Basic Settings** → **Frontend** → **Login / Registration**
* Set the "Show phone number field" to "Yes"
* Click **Configuration** → **Cache/performance** → **Clear shop cache**
* Go to **Configuration** → **Payment methods** → **Wirecard Garantierter Kauf auf Rechnung**
* Tick the "Active" checkbox and hit "Save" – the payment method should be activated now
