### PR TITLE
Update get-shopware-versions.sh

### DIFF
--- a/.bin/get-shopware-versions.sh
+++ b/.bin/get-shopware-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #get last 3  releases
-curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/shopware/shopware/releases | jq -r '.[] | .tag_name' | head -3 > ${SHOPWARE_RELEASES_FILE}
+curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/shopware/shopware/releases | jq -r '.[] | .tag_name' | egrep -v [A-Z] | head -3 > ${SHOPWARE_RELEASES_FILE}
 git config --global user.name "Travis CI"
 git config --global user.email "wirecard@travis-ci.org"
 


### PR DESCRIPTION
When polling shopware repository and creating a list of shop versions to be UI tested, do not take RC versions into account