### PR TITLE
Update WirecardElasticEngine.php

### DIFF
--- a/WirecardElasticEngine.php
+++ b/WirecardElasticEngine.php
@@ -291,8 +291,8 @@ class WirecardElasticEngine extends Plugin
             Shopware()->Db()->update('s_core_paymentmeans', ['description' => $description], 'id=' . $paymentId);
             return;
         }
-
-        $translationObject = new \Shopware_Components_Translation();
+        /* get translationObject from container */
+        $translationObject = $this->container->has('translation') ? $this->container->get('translation') : new \Shopware_Components_Translation();
         $translationObject->write($shopId, 'config_payment', $paymentId, ['description' => $description], true);
     }
 }


### PR DESCRIPTION
Update translation object creation. 
Sometimes the code "$translationObject = new \Shopware_Components_Translation();" can cause the installation process to stop.
Getting the object from the container (like in the PayPal Plugin from Shopware) prevents this.